### PR TITLE
A fix for Trinket and Accessory incompatibility bugs 1.21.1

### DIFF
--- a/src/main/java/net/pneumono/gravestones/Gravestones.java
+++ b/src/main/java/net/pneumono/gravestones/Gravestones.java
@@ -9,6 +9,7 @@ import net.minecraft.util.Identifier;
 import net.pneumono.gravestones.api.InsertGravestoneItemCallback;
 import net.pneumono.gravestones.compat.AccessoriesCompat;
 import net.pneumono.gravestones.compat.BackwardsCompat;
+import net.pneumono.gravestones.compat.InventoryModManager;
 import net.pneumono.gravestones.compat.TrinketsCompat;
 import net.pneumono.gravestones.content.GravestonesCommands;
 import net.pneumono.gravestones.content.GravestonesRegistry;
@@ -38,17 +39,15 @@ public class Gravestones implements ModInitializer {
 			InsertGravestoneItemCallback.EVENT.register((player, itemStack) -> itemStack.isOf(Items.RECOVERY_COMPASS));
 		}
 
-		// Accessories' Compat Layers exist, so to prevent issues Gravestones will prioritize Accessories directly over other mods
-		boolean usingAccessories = false;
-
 		if (isModLoaded("accessories")) {
 			AccessoriesCompat.register();
-			usingAccessories = true;
 		}
 
-		if (!usingAccessories && isModLoaded("trinkets")) {
+		if (isModLoaded("trinkets")) {
 			TrinketsCompat.register();
 		}
+
+		InventoryModManager.INSTANCE.init();
 	}
 
 	private static boolean isModLoaded(String id) {

--- a/src/main/java/net/pneumono/gravestones/compat/AccessoriesCompat.java
+++ b/src/main/java/net/pneumono/gravestones/compat/AccessoriesCompat.java
@@ -5,6 +5,6 @@ import net.pneumono.gravestones.api.GravestonesApi;
 
 public class AccessoriesCompat {
     public static void register() {
-        GravestonesApi.registerDataType(Gravestones.id("accessories"), new AccessoriesDataType());
+        InventoryModManager.INSTANCE.registerInventoryMod(new AccessoriesDataType(), Gravestones.id("accessories"));
     }
 }

--- a/src/main/java/net/pneumono/gravestones/compat/AccessoriesDataType.java
+++ b/src/main/java/net/pneumono/gravestones/compat/AccessoriesDataType.java
@@ -19,6 +19,7 @@ import net.minecraft.registry.DynamicRegistryManager;
 import net.minecraft.util.ItemScatterer;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+import net.pneumono.gravestones.Gravestones;
 import net.pneumono.gravestones.api.GravestoneDataType;
 import net.pneumono.gravestones.api.GravestonesApi;
 
@@ -26,7 +27,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
-public class AccessoriesDataType extends GravestoneDataType {
+public class AccessoriesDataType implements InventoryMod {
+    @Override
+    public String getId() {
+        return "accessories";
+    }
+
     @Override
     public void writeData(NbtCompound view, PlayerEntity player) {
         AccessoriesCapability capability = AccessoriesCapability.get(player);

--- a/src/main/java/net/pneumono/gravestones/compat/InventoryMod.java
+++ b/src/main/java/net/pneumono/gravestones/compat/InventoryMod.java
@@ -1,0 +1,17 @@
+package net.pneumono.gravestones.compat;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+// Interface like GravestoneDataType, but for inventory mods specifically
+public interface InventoryMod {
+    String getId();
+
+    void writeData(NbtCompound view, PlayerEntity player);
+
+    void onBreak(NbtCompound view, World world, BlockPos pos, int decay);
+
+    void onCollect(NbtCompound view, World world, BlockPos pos, PlayerEntity player, int decay);
+}

--- a/src/main/java/net/pneumono/gravestones/compat/InventoryModManager.java
+++ b/src/main/java/net/pneumono/gravestones/compat/InventoryModManager.java
@@ -1,0 +1,98 @@
+package net.pneumono.gravestones.compat;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.pneumono.gravestones.Gravestones;
+import net.pneumono.gravestones.api.GravestoneDataType;
+import net.pneumono.gravestones.api.GravestonesApi;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Manager for handling all inventory mods
+ */
+public class InventoryModManager extends GravestoneDataType {
+    public static final InventoryModManager INSTANCE = new InventoryModManager();
+    private final List<InventoryModRecord> inventoryModList = new ArrayList<>();
+
+    private InventoryModManager() {}
+
+    /**
+     * Registers an inventory mod to the manager
+     * @param inventoryMod
+     * @param modId
+     */
+    public void registerInventoryMod(InventoryMod inventoryMod, Identifier modId) {
+        inventoryModList.add(new InventoryModRecord(inventoryMod, modId));
+    }
+
+    public void init() {
+        GravestonesApi.registerDataType(Gravestones.id("inventory_mods"), this);
+
+        // Register a fallback adapter for gravestones that didn't use this class
+        for (InventoryModRecord i : inventoryModList) {
+            if (i.modId != null) {
+                GravestonesApi.registerDataType(i.modId, new FallbackAdapter(i.inventory));
+            }
+        }
+    }
+
+    @Override
+    public void writeData(NbtCompound view, PlayerEntity player) {
+        Gravestones.LOGGER.info("InventoryModManager: Saving data...");
+        NbtCompound modData = new NbtCompound();
+        for (InventoryModRecord i : inventoryModList) {
+            i.inventory.writeData(modData, player);
+        }
+        view.put("items", modData);
+    }
+
+    @Override
+    public void onBreak(NbtCompound view, World world, BlockPos pos, int decay) {
+        if (view.contains("items")) {
+            NbtCompound modData = view.getCompound("items");
+            for (InventoryModRecord inventoryModRecord : inventoryModList) {
+                inventoryModRecord.inventory.onBreak(modData, world, pos, decay);
+            }
+        }
+    }
+
+    @Override
+    public void onCollect(NbtCompound view, World world, BlockPos pos, PlayerEntity player, int decay) {
+        if (view.contains("items")) {
+            NbtCompound modData = view.getCompound("items");
+            for (InventoryModRecord inventoryModRecord : inventoryModList) {
+                inventoryModRecord.inventory.onCollect(modData, world, pos, player, decay);
+            }
+        }
+    }
+
+    private record InventoryModRecord(InventoryMod inventory, Identifier modId) {}
+
+    private static class FallbackAdapter extends GravestoneDataType {
+        private final InventoryMod inventoryMod;
+
+        public FallbackAdapter(InventoryMod inventoryMod) {
+            this.inventoryMod = inventoryMod;
+        }
+
+        @Override
+        public void writeData(NbtCompound view, PlayerEntity player) {
+            // Fallback adapter does not write data
+        }
+
+        @Override
+        public void onBreak(NbtCompound view, World world, BlockPos pos, int decay) {
+            inventoryMod.onBreak(view, world, pos, decay);
+        }
+
+        @Override
+        public void onCollect(NbtCompound view, World world, BlockPos pos, PlayerEntity player, int decay) {
+            inventoryMod.onCollect(view, world, pos, player, decay);
+        }
+    }
+}

--- a/src/main/java/net/pneumono/gravestones/compat/TrinketsCompat.java
+++ b/src/main/java/net/pneumono/gravestones/compat/TrinketsCompat.java
@@ -5,6 +5,6 @@ import net.pneumono.pneumonocore.PneumonoCore;
 
 public class TrinketsCompat {
     public static void register() {
-        GravestonesApi.registerDataType(PneumonoCore.identifier("trinkets"), new TrinketsDataType());
+        InventoryModManager.INSTANCE.registerInventoryMod(new TrinketsDataType(), PneumonoCore.identifier("trinkets"));
     }
 }

--- a/src/main/java/net/pneumono/gravestones/compat/TrinketsDataType.java
+++ b/src/main/java/net/pneumono/gravestones/compat/TrinketsDataType.java
@@ -18,6 +18,7 @@ import net.minecraft.registry.DynamicRegistryManager;
 import net.minecraft.util.ItemScatterer;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+import net.pneumono.gravestones.Gravestones;
 import net.pneumono.gravestones.api.GravestoneDataType;
 import net.pneumono.gravestones.api.GravestonesApi;
 
@@ -25,16 +26,24 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-public class TrinketsDataType extends GravestoneDataType {
-    public static final Codec<Pair<SlotReferencePrimitive, ItemStack>> SLOT_CODEC = RecordCodecBuilder.create(builder -> builder.group(
-            SlotReferencePrimitive.CODEC.fieldOf("slot").forGetter(Pair::getFirst),
-            ItemStack.CODEC.fieldOf("stack").forGetter(Pair::getSecond)
-    ).apply(builder, Pair<SlotReferencePrimitive, ItemStack>::new));
+import java.util.Optional;
+
+public class TrinketsDataType implements InventoryMod {
+    public static final Codec<Pair<SlotReferencePrimitive, ItemStack>> SLOT_CODEC = Codec.pair(
+            SlotReferencePrimitive.CODEC.fieldOf("slot").codec(),
+            ItemStack.CODEC.fieldOf("item").codec()
+    );
+
+    @Override
+    public String getId() {
+        return "trinkets";
+    }
 
     @Override
     public void writeData(NbtCompound view, PlayerEntity player) {
-        TrinketComponent component = TrinketsApi.getTrinketComponent(player).orElse(null);
-        if (component == null) return;
+        Optional<TrinketComponent> optional = TrinketsApi.getTrinketComponent(player);
+        if (optional.isEmpty()) return;
+        TrinketComponent component = optional.get();
 
         List<Pair<SlotReferencePrimitive, ItemStack>> storedTrinkets = new ArrayList<>();
         component.forEach((reference, stack) -> {


### PR DESCRIPTION
Hello,

This is my first time forking, making a PR and working on a minecraft mod. Sorry if I didn't follow the proper practices/conventions!

I was using a backpack mod which is prefers trinket over accessory. I noticed the backpack kept getting thrown out of the gravestone and figured out it's because of the temporary fix you made to prefer accessory. I made an interface for inventory slot mods like you already have with the GravestoneDataType, since it was an abstract class I didn't want to touch it and change anything. I wanted to try and make something so anytime a new inventory slot mod gets added, you can easily plug it in after making an Compat class for it. There is also backwards compatibility for gravestones that were made without this change. So that if it can't find the data type I made, "inventory_mods" in the file, then it looks if it is "accessories" or "trinkets". 

I tried my best to understand Trinkets and Accessories API, from what I understood, the Accessories mod kind of manages Trinkets, so again Accessories takes priority, but now gravestone can see from the file that if accessories moved it, then the others shouldn't.

Again, I'm not a minecraft mod developer, this is my first time ever even looking at minecraft mod code, so I am not sure if everything really works together well, if it doesn't hopefully this gives you a good starting point. So far my friends and I have had no issues!