### PR TITLE
fixed crash caused by incorrect NBT data

### DIFF
--- a/src/main/java/net/pneumono/gravestones/content/PlayerInventoryDataType.java
+++ b/src/main/java/net/pneumono/gravestones/content/PlayerInventoryDataType.java
@@ -33,8 +33,14 @@ public class PlayerInventoryDataType extends GravestoneDataType {
             Identifier slotIdentifier = VersionUtil.createId("minecraft", Integer.toString(i));
             GravestonesApi.onInsertItem(player, itemStack, slotIdentifier);
             if (!GravestonesApi.shouldSkipItem(player, itemStack, slotIdentifier) && !itemStack.isEmpty()) {
-                DataResult<Tag> result = StackWithSlot.CODEC.encodeStart(ops, new StackWithSlot(i, inventory.removeItemNoUpdate(i)));
-                list.add(result.result().orElseThrow());
+                ItemStack stackToSave = inventory.removeItemNoUpdate(i);
+                DataResult<Tag> result = StackWithSlot.CODEC.encodeStart(ops, new StackWithSlot(i, stackToSave));
+                if (result.result().isPresent()) {
+                    list.add(result.result().get());
+                } else {
+                    Gravestones.LOGGER.error("Failed to serialize item {} for gravestone: {}", stackToSave, result.error().get().message());
+                    player.drop(stackToSave, true, false);
+                }
             }
         }
         tag.put(KEY, list);
@@ -45,8 +51,10 @@ public class PlayerInventoryDataType extends GravestoneDataType {
         ListTag list = VersionUtil.getCompoundListOrEmpty(tag, KEY);
 
         for (Tag element : list) {
-            ItemStack stack = StackWithSlot.CODEC.decode(ops, element).result().orElseThrow().getFirst().stack();
-            dropStack(level, pos, stack);
+            StackWithSlot.CODEC.decode(ops, element).resultOrPartial(Gravestones.LOGGER::error).ifPresent(pair -> {
+                ItemStack stack = pair.getFirst().stack();
+                dropStack(level, pos, stack);
+            });
         }
     }
 
@@ -56,7 +64,7 @@ public class PlayerInventoryDataType extends GravestoneDataType {
         ListTag list = VersionUtil.getCompoundListOrEmpty(tag, KEY);
         List<StackWithSlot> stacks = new ArrayList<>();
         for (Tag element : list) {
-            stacks.add(StackWithSlot.CODEC.decode(ops, element).result().orElseThrow().getFirst());
+            StackWithSlot.CODEC.decode(ops, element).resultOrPartial(Gravestones.LOGGER::error).ifPresent(pair -> stacks.add(pair.getFirst()));
         }
 
         List<ItemStack> remainingStacks = new ArrayList<>();


### PR DESCRIPTION
```
[19:19:52] [Server thread/ERROR]: Gravestone Data Type 'gravestones:inventory' failed to write data:
java.util.NoSuchElementException: No value present
	at java.base/java.util.Optional.orElseThrow(Optional.java:377)
	at knot//net.pneumono.gravestones.content.PlayerInventoryDataType.writeData(PlayerInventoryDataType.java:37)
	at knot//net.pneumono.gravestones.api.GravestonesApi.getDataToInsert(GravestonesApi.java:138)
	at knot//net.pneumono.gravestones.gravestones.GravestoneCreation.createContentsData(GravestoneCreation.java:145)
	at knot//net.pneumono.gravestones.gravestones.GravestoneCreation.create(GravestoneCreation.java:112)
	at knot//net.pneumono.gravestones.gravestones.GravestoneCreation.create(GravestoneCreation.java:40)
	at knot//net.minecraft.class_1309.handler$cfp000$gravestones$spawnGravestone(class_1309.java:23694)
	at knot//net.minecraft.class_1309.method_16080(class_1309.java)
	at knot//net.minecraft.class_3222.method_6078(class_3222.java:968)
	at knot//net.minecraft.class_1309.method_64397(class_1309.java:1318)
	at knot//net.minecraft.class_1657.method_64397(class_1657.java:796)
	at knot//net.minecraft.class_3222.method_64397(class_3222.java:1050)
	at knot//net.minecraft.class_1308.method_6121(class_1308.java:1474)
	at knot//net.minecraft.class_7260.method_6121(class_7260.java:251)
	at knot//net.minecraft.class_4816.method_46990(class_4816.java:31)
	at knot//net.minecraft.class_7898$1.trigger(class_7898.java:53)
	at knot//net.minecraft.class_7894.method_18922(class_7894.java:20)
	at knot//net.minecraft.class_4095.method_18891(class_4095.java:1245)
	at knot//net.minecraft.class_4095.method_19542(class_4095.java:497)
	at knot//net.minecraft.class_7260.method_5958(class_7260.java:312)
	at knot//net.minecraft.class_1308.method_6023(class_1308.java:786)
	at knot//net.minecraft.class_1309.method_6007(class_1309.java:3110)
	at knot//net.minecraft.class_1308.method_6007(class_1308.java:498)
	at knot//net.minecraft.class_1588.method_6007(class_1588.java:46)
	at knot//net.minecraft.class_1309.method_5773(class_1309.java:2818)
	at knot//net.minecraft.class_1308.method_5773(class_1308.java:360)
	at knot//net.minecraft.class_7260.method_5773(class_7260.java:279)
	at knot//net.minecraft.class_3218.method_18762(class_3218.java:838)
	at knot//net.minecraft.class_1937.method_18472(class_1937.java:490)
	at knot//net.minecraft.class_3218.method_31420(class_3218.java:433)
	at knot//net.minecraft.class_5574.method_31791(class_5574.java:53)
	at knot//net.minecraft.class_3218.method_18765(class_3218.java:403)
	at knot//net.minecraft.server.MinecraftServer.method_3813(MinecraftServer.java:1145)
	at knot//net.minecraft.server.MinecraftServer.method_3748(MinecraftServer.java:1016)
	at knot//net.minecraft.class_3176.method_3748(class_3176.java:318)
	at knot//net.minecraft.server.MinecraftServer.method_76677(MinecraftServer.java:1049)
	at knot//net.minecraft.server.MinecraftServer.method_29741(MinecraftServer.java:771)
	at knot//net.minecraft.server.MinecraftServer.method_29739(MinecraftServer.java:301)
	at java.base/java.lang.Thread.run(Thread.java:1474)
```

Fixed NoSuchElementException server crash during gravestone creation when an item fails to serialize (e.g. due to invalid NBT like max_damage: 0).
- Replaced .orElseThrow() with DataResult validation. If an item fails to serialize, the error is logged and the item is safely dropped at the player's death location, preventing the crash and saving the rest of the gravestone.
- Added resultOrPartial for decoding to gracefully handle and log errors when reading pre-existing gravestones with corrupted item data, preventing crashes during grave collection/breaking.